### PR TITLE
Update spatialdb.pp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(prefix)/python:
 	git clone https://github.com/puppetmodules/puppet-module-python.git $@
 
 $(prefix)/nginx:
-	git clone https://github.com/jfryman/puppet-nginx.git $@ && git stash && \
+	git clone https://github.com/jfryman/puppet-nginx.git $@ && \
 		git --git-dir=$@/.git checkout 17d1edaf74
 
 # Checkout git based dependencies.

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,9 @@ $(prefix)/python:
 	git clone https://github.com/puppetmodules/puppet-module-python.git $@
 
 $(prefix)/nginx:
-	git clone https://github.com/jfryman/puppet-nginx.git $@ && \
-		git --git-dir=$@/.git checkout 17d1edaf74
+	git clone https://github.com/jfryman/puppet-nginx.git $@
+	        #&& \
+		# git --git-dir=$@/.git checkout 17d1edaf74
 
 # Checkout git based dependencies.
 checkouts: $(prefix)/python $(prefix)/nginx

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(prefix)/python:
 	git clone https://github.com/puppetmodules/puppet-module-python.git $@
 
 $(prefix)/nginx:
-	git clone https://github.com/jfryman/puppet-nginx.git $@ && \
+	git clone https://github.com/jfryman/puppet-nginx.git $@ && git stash && \
 		git --git-dir=$@/.git checkout 17d1edaf74
 
 # Checkout git based dependencies.

--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -20,7 +20,7 @@ define django::app (
   # for app and venv subdirs while allowing the gunicorn daemon to run as an
   # unprivileged user. Work around that here.
   python::venv::isolate { $venvdir: } ->
-  exec { "chown root:root ${vhostdocroot}": } ->
+  exec { "/bin/sh chown root:root ${vhostdocroot}": } ->
   file { "$vhostdocroot/$name":
     ensure => directory,
   }

--- a/manifests/spatialdb.pp
+++ b/manifests/spatialdb.pp
@@ -1,7 +1,7 @@
 # Enable PostGIS for the database.
 define django::spatialdb ($dbname, $pguser='postgres') {
   include django::postgis
-  $psql = "sudo -u ${pguser} psql -d ${dbname} -c"
+  $psql = "/bin/sh sudo -u ${pguser} psql -d ${dbname} -c"
   exec { "${psql} 'CREATE EXTENSION postgis;'":
     unless => "${psql} 'select postgis_version();'",
     require => Postgresql::Db[$dbname],


### PR DESCRIPTION
It seems to be necessary to call the shell explicitly if you run shell commands. It was not the case in older versions of puppet and there seems to be a lot of discussion whether or not this should be the behaviour. Nevertheless, it works that way. The error I got prior that change was "Could not find command sudo" 

See among others:

https://groups.google.com/forum/#!topic/puppet-users/LWlzPpjKJOA

According to the forum entries it did not make it in the ChangeLogs. Unfortunately, I did not found any hints on that issue referring to Puppet 3.  
